### PR TITLE
docs: add Amp, Zed, and Warp to all target enumerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Prefer a local install? `npm install -D agentsmesh` (also `pnpm add -D` / `yarn 
 If your repo already has `.cursor/`, `.claude/`, `.github/copilot-instructions.md`, or other native files, you don't have to delete them. The recommended flow imports them into `.agentsmesh/` first, lets you preview the projection, and only then trusts `generate`.
 
 ```bash
-npx agentsmesh import --from cursor   # or claude-code, copilot, codex-cli, gemini-cli, windsurf, ...
+npx agentsmesh import --from cursor   # or claude-code, copilot, codex-cli, gemini-cli, windsurf, amp, zed, warp, ...
 npx agentsmesh diff                   # patch-style preview of what generate would change
 npx agentsmesh generate               # write native configs (back) from canonical
 npx agentsmesh check                  # add to CI to detect drift
@@ -121,7 +121,7 @@ On macOS/Linux you can also run `tree .agentsmesh` if you have `tree` installed.
 
 ## Supported AI coding tools
 
-AgentsMesh currently generates native config for every major AI coding assistant — Claude Code, Cursor, GitHub Copilot, Gemini CLI, Windsurf, Continue, Cline, Kiro, Codex CLI, Junie, Roo Code, Antigravity — plus plugin targets you can ship as standalone npm packages. Each tool's native vs. embedded support per feature is tracked in the [supported tools matrix](https://samplexbro.github.io/agentsmesh/reference/supported-tools/). The full matrix table is also embedded [further down this README](#supported-tools--feature-matrix).
+AgentsMesh currently generates native config for every major AI coding assistant — Claude Code, Cursor, GitHub Copilot, Gemini CLI, Windsurf, Continue, Cline, Kiro, Codex CLI, Junie, Roo Code, Antigravity, Amp, Zed, Warp — plus plugin targets you can ship as standalone npm packages. Each tool's native vs. embedded support per feature is tracked in the [supported tools matrix](https://samplexbro.github.io/agentsmesh/reference/supported-tools/). The full matrix table is also embedded [further down this README](#supported-tools--feature-matrix).
 
 ---
 
@@ -147,7 +147,7 @@ The reason `AGENTS.md` alone is not enough: most AI coding assistants expose con
 - **GitHub Copilot** has `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, agents, prompts, and (partial) hooks.
 - **Gemini CLI** has `GEMINI.md`, `.gemini/settings.json` (MCP + hooks), `.gemini/commands/*.toml`, and agents.
 - **Codex CLI** has `AGENTS.md` plus `.codex/config.toml`, `.codex/agents/*.toml`, and `.codex/rules/`.
-- **Windsurf**, **Continue**, **Cline**, **Kiro**, **Junie**, **Roo Code**, **Antigravity** each have their own native rules, workflows, MCP servers, skills, and ignore files.
+- **Windsurf**, **Continue**, **Cline**, **Kiro**, **Junie**, **Roo Code**, **Antigravity**, **Amp**, **Zed**, **Warp** each have their own native rules, workflows, MCP servers, skills, and ignore files.
 
 AgentsMesh canonicalizes all of these — rules, commands, agents, skills, MCP servers, hooks, ignore patterns, permissions — so you don't pick one tool's surface as the lowest common denominator. When a tool has no native slot for a feature, AgentsMesh embeds it with round-trip metadata instead of dropping it.
 

--- a/website/src/content/docs/getting-started/quick-start.mdx
+++ b/website/src/content/docs/getting-started/quick-start.mdx
@@ -83,7 +83,7 @@ Choose the path that matches your situation.
    agentsmesh init
    ```
 
-   AgentsMesh scans for existing configs in `.claude/`, `.cursor/`, `.cline/`, `.junie/`, `.kiro/`, `.continue/`, `.gemini/`, `.codex/`, `.windsurf/`, and `.github/copilot-instructions.md`. It prompts you to import each one found.
+   AgentsMesh scans for existing configs in `.claude/`, `.cursor/`, `.cline/`, `.junie/`, `.kiro/`, `.continue/`, `.gemini/`, `.codex/`, `.windsurf/`, `.amp/`, `.warp/`, `.zed/`, and `.github/copilot-instructions.md`. It prompts you to import each one found.
 
    To auto-import everything without prompts:
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -45,7 +45,7 @@ import SoftwareApplicationJsonLd from '../../components/SoftwareApplicationJsonL
 
 ## AI coding config should not drift between tools
 
-Every AI coding assistant ships a different configuration surface. Claude Code reads `CLAUDE.md` and `.claude/settings.json`. Cursor uses `.cursor/rules/*.mdc`. GitHub Copilot reads `.github/copilot-instructions.md` and prompts. Gemini CLI, Windsurf, Continue, Cline, Kiro, Codex CLI, Junie, Roo Code, and Antigravity each add their own files for rules, commands, agents, skills, MCP servers, hooks, ignore patterns, or permissions.
+Every AI coding assistant ships a different configuration surface. Claude Code reads `CLAUDE.md` and `.claude/settings.json`. Cursor uses `.cursor/rules/*.mdc`. GitHub Copilot reads `.github/copilot-instructions.md` and prompts. Gemini CLI, Windsurf, Continue, Cline, Kiro, Codex CLI, Junie, Roo Code, Antigravity, Amp, Zed, and Warp each add their own files for rules, commands, agents, skills, MCP servers, hooks, ignore patterns, or permissions.
 
 AgentsMesh turns that spread into one editable source of truth. Put the real project instructions in `.agentsmesh/`, then generate native files for every enabled tool. Import goes the other direction, so existing tool configs can be adopted without starting from scratch.
 

--- a/website/src/content/docs/reference/supported-tools.mdx
+++ b/website/src/content/docs/reference/supported-tools.mdx
@@ -1,7 +1,7 @@
 ---
 draft: false
 title: Supported Tools Matrix
-description: Complete feature-target compatibility matrix for every AI coding tool supported by AgentsMesh, including Claude Code, Cursor, Copilot, Continue, Junie, Kiro, Gemini CLI, Cline, Codex CLI, Windsurf, Antigravity, Roo Code, and more as they ship.
+description: Complete feature-target compatibility matrix for every AI coding tool supported by AgentsMesh, including Claude Code, Cursor, Copilot, Continue, Junie, Kiro, Gemini CLI, Cline, Codex CLI, Windsurf, Antigravity, Roo Code, Amp, Zed, Warp, and more as they ship.
 ---
 
 AgentsMesh supports every major AI coding tool. This page documents what each tool supports natively, what is embedded/projected, and what is not supported.


### PR DESCRIPTION
Update README, website index, quick-start, and supported-tools description to include the three new targets in narrative lists.

## What does this PR do?

<!-- One sentence summary -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Test coverage

## Checklist

- [ ] Tests written first (TDD)
- [ ] All CI checks pass (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
- [ ] Changeset added (`pnpm changeset`) for user-visible changes
