### PR TITLE
ci(website): bump pnpm to 10 to match repo

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
The root `pnpm-workspace.yaml` added for pnpm 11 build-script approval breaks pnpm 9, which treats the file as a strict monorepo manifest and requires a `packages:` field. pnpm 10+ reads it as a general config file. Matches the other workflows (ci.yml, publish.yml) which already use pnpm 10. Website's `pnpm-lock.yaml` is lockfile v9.0 which pnpm 10 reads natively.

## What does this PR do?

<!-- One sentence summary -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test coverage

## Checklist

- [ ] Tests written first (TDD)
- [ ] All CI checks pass (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
- [ ] Changeset added (`pnpm changeset`) for user-visible changes
