### PR TITLE
fix(website): shadow root pnpm-workspace.yaml

### DIFF
--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# Shadows the root pnpm-workspace.yaml so `pnpm install` in website/
+# installs into website/node_modules instead of walking up to the
+# repo root (which has settings for the main package, not this site).
+packages:
+  - .


### PR DESCRIPTION
The root `pnpm-workspace.yaml` (added for pnpm 11 build-script approval) makes pnpm 10 walk up from website/ and treat the repo as a workspace with no members, skipping the install entirely. Adding a minimal `packages: ['.']` workspace file inside website/ shadows the parent so `pnpm install` in this directory installs into website/node_modules as expected, fixing the deploy-website job's "astro: not found" failure.

## What does this PR do?

<!-- One sentence summary -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test coverage

## Checklist

- [ ] Tests written first (TDD)
- [ ] All CI checks pass (`pnpm test`, `pnpm lint`, `pnpm typecheck`)
- [ ] Changeset added (`pnpm changeset`) for user-visible changes
