### PR TITLE
fix(check): detect generated-output drift

### DIFF
--- a/.changeset/check-generated-output-drift.md
+++ b/.changeset/check-generated-output-drift.md
@@ -1,0 +1,5 @@
+---
+"agentsmesh": patch
+---
+
+Make `agentsmesh check` fail on modified, missing, or stale generated outputs and report canonical and output drift separately in JSON output.

--- a/src/cli/command-result.ts
+++ b/src/cli/command-result.ts
@@ -65,12 +65,22 @@ export interface LintData {
 
 export interface CheckData {
   hasLock: boolean;
+  /** True when canonical files or extends differ from the collaboration lock. */
+  canonicalDrift: boolean;
+  /** True when generated outputs differ from the current canonical projection. */
+  outputDrift: boolean;
   inSync: boolean;
   modified: string[];
   added: string[];
   removed: string[];
   extendsModified: string[];
   lockedViolations: string[];
+  /** Generated files whose contents differ from the canonical projection. */
+  outputModified: string[];
+  /** Generated files expected from the canonical projection but missing on disk. */
+  outputRemoved: string[];
+  /** Managed generated files that are no longer part of the canonical projection. */
+  outputStale: string[];
 }
 
 export interface MergeData {

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -1,11 +1,12 @@
 /**
  * agentsmesh check — CI integration for team collaboration.
- * Verifies canonical files match the lock file.
+ * Verifies canonical files and generated outputs are in sync.
  */
 
 import { loadScopedConfig } from '../../config/core/scope.js';
 import { checkLockSync } from '../../core/check/lock-sync.js';
-import { bootstrapPlugins } from '../../plugins/bootstrap-plugins.js';
+import { findStaleGeneratedOutputs } from '../../core/generate/stale-cleanup.js';
+import { runGenerate } from './generate.js';
 import type { CheckData } from '../command-result.js';
 
 export interface CheckCommandResult {
@@ -15,7 +16,7 @@ export interface CheckCommandResult {
 
 /**
  * Run the check command.
- * @param flags - CLI flags (unused for check)
+ * @param flags - CLI flags
  * @param projectRoot - Project root (default process.cwd())
  * @returns Structured check result with exit code and data
  */
@@ -27,39 +28,71 @@ export async function runCheck(
   const scope = flags.global === true ? 'global' : 'project';
 
   const { config, context } = await loadScopedConfig(root, scope);
-  await bootstrapPlugins(config, root);
-
   const report = await checkLockSync({
     config,
     configDir: context.configDir,
     canonicalDir: context.canonicalDir,
   });
 
+  const outputCheck = report.hasLock
+    ? await runGenerate({ ...flags, check: true, force: true }, root, { printMatrix: false })
+    : null;
+  const outputModified = [
+    ...new Set(
+      outputCheck?.data.files.filter((file) => file.status === 'updated').map((file) => file.path),
+    ),
+  ].sort();
+  const outputRemoved = [
+    ...new Set(
+      outputCheck?.data.files.filter((file) => file.status === 'created').map((file) => file.path),
+    ),
+  ].sort();
+  const outputStale = outputCheck
+    ? await findStaleGeneratedOutputs({
+        projectRoot: context.rootBase,
+        targets: [...config.targets, ...config.pluginTargets],
+        expectedPaths: outputCheck.data.files.map((file) => file.path),
+        scope,
+      })
+    : [];
+  const outputDrift = outputCheck?.exitCode === 1 || outputStale.length > 0;
+
   if (!report.hasLock) {
     return {
       exitCode: 1,
       data: {
         hasLock: false,
+        canonicalDrift: false,
+        outputDrift: false,
         inSync: false,
         modified: [],
         added: [],
         removed: [],
         extendsModified: [],
         lockedViolations: [],
+        outputModified: [],
+        outputRemoved: [],
+        outputStale: [],
       },
     };
   }
 
+  const inSync = report.inSync && !outputDrift;
   return {
-    exitCode: report.inSync ? 0 : 1,
+    exitCode: inSync ? 0 : 1,
     data: {
       hasLock: true,
-      inSync: report.inSync,
+      canonicalDrift: !report.inSync,
+      outputDrift,
+      inSync,
       modified: [...report.modified],
       added: [...report.added],
       removed: [...report.removed],
       extendsModified: [...report.extendsModified],
       lockedViolations: [...report.lockedViolations],
+      outputModified,
+      outputRemoved,
+      outputStale,
     },
   };
 }

--- a/src/cli/renderers/check.ts
+++ b/src/cli/renderers/check.ts
@@ -14,11 +14,16 @@ export function renderCheck(result: CheckCommandResult): void {
   }
 
   if (data.inSync) {
-    ui.note('Lock file is in sync.', 'Check');
-    ui.success('Lock file is in sync.');
+    ui.note('Lock file is in sync; generated outputs are in sync.', 'Check');
+    ui.success('Lock file is in sync; generated outputs are in sync.');
     return;
   }
 
+  if (data.canonicalDrift) renderCanonicalDrift(data);
+  if (data.outputDrift) renderOutputDrift(data);
+}
+
+function renderCanonicalDrift(data: CheckCommandResult['data']): void {
   const lockedSet = new Set(data.lockedViolations);
   ui.error('Conflict detected:');
   for (const p of data.extendsModified) {
@@ -36,8 +41,22 @@ export function renderCheck(result: CheckCommandResult): void {
     const suffix = lockedSet.has(p) ? ' [LOCKED]' : '';
     ui.error(`  ${p} was removed${suffix}`);
   }
-  ui.note('Generated files are out of sync.', 'Check');
   ui.info(
     "Run 'agentsmesh merge' to resolve, or 'agentsmesh generate --force' to accept current state.",
   );
+}
+
+function renderOutputDrift(data: CheckCommandResult['data']): void {
+  ui.error('Generated output drift detected:');
+  for (const path of data.outputModified) {
+    ui.error(`  ${path} was modified`);
+  }
+  for (const path of data.outputRemoved) {
+    ui.error(`  ${path} is missing`);
+  }
+  for (const path of data.outputStale) {
+    ui.error(`  ${path} is stale (no longer generated)`);
+  }
+  ui.note('Generated files are out of sync.', 'Check');
+  ui.info("Run 'agentsmesh generate' and commit the updated outputs.");
 }

--- a/src/core/generate/stale-cleanup.ts
+++ b/src/core/generate/stale-cleanup.ts
@@ -18,22 +18,16 @@ async function listFiles(root: string, base = root): Promise<string[]> {
   return files;
 }
 
-async function removeIfStale(
-  projectRoot: string,
-  relPath: string,
-  expected: Set<string>,
-): Promise<void> {
-  if (expected.has(relPath)) return;
-  const abs = join(projectRoot, relPath);
-  if (await exists(abs)) await rm(abs, { recursive: true, force: true });
-}
-
-export async function cleanupStaleGeneratedOutputs(args: {
+interface StaleGeneratedOutputsArgs {
   projectRoot: string;
   targets: string[];
   expectedPaths: string[];
   scope?: TargetLayoutScope;
-}): Promise<void> {
+}
+
+export async function findStaleGeneratedOutputs(
+  args: StaleGeneratedOutputsArgs,
+): Promise<string[]> {
   const expected = new Set(args.expectedPaths);
   const stale = new Set<string>();
   const scope = args.scope ?? 'project';
@@ -51,7 +45,19 @@ export async function cleanupStaleGeneratedOutputs(args: {
     }
   }
 
+  const found: string[] = [];
   for (const relPath of stale) {
-    await removeIfStale(args.projectRoot, relPath, expected);
+    if (expected.has(relPath)) continue;
+    if (await exists(join(args.projectRoot, relPath))) found.push(relPath);
+  }
+  return found.sort();
+}
+
+export async function cleanupStaleGeneratedOutputs(
+  args: StaleGeneratedOutputsArgs,
+): Promise<void> {
+  const stale = await findStaleGeneratedOutputs(args);
+  for (const relPath of stale) {
+    await rm(join(args.projectRoot, relPath), { recursive: true, force: true });
   }
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,13 +1,3 @@
-# Issue #98 - make `check` detect generated-output drift (ACTIVE)
-
-- [ ] Add a regression test proving `check` fails after a generated file is edited.
-- [ ] Expose canonical drift and output drift separately in structured check results.
-- [ ] Reuse the generation check path without changing the public lock-sync API contract.
-- [ ] Update CLI documentation and human-readable output.
-- [ ] Run focused tests, full verification, and post-feature QA.
-
----
-
 # Lessons coverage completion — capture/recall at the right time, for all types (ACTIVE)
 
 **Goal (user):** lessons must be *captured and queried when they are really needed*; general,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,13 @@
+# Issue #98 - make `check` detect generated-output drift (ACTIVE)
+
+- [ ] Add a regression test proving `check` fails after a generated file is edited.
+- [ ] Expose canonical drift and output drift separately in structured check results.
+- [ ] Reuse the generation check path without changing the public lock-sync API contract.
+- [ ] Update CLI documentation and human-readable output.
+- [ ] Run focused tests, full verification, and post-feature QA.
+
+---
+
 # Lessons coverage completion — capture/recall at the right time, for all types (ACTIVE)
 
 **Goal (user):** lessons must be *captured and queried when they are really needed*; general,

--- a/tests/integration/json-output.integration.test.ts
+++ b/tests/integration/json-output.integration.test.ts
@@ -93,10 +93,7 @@ describe('agentsmesh --json output (integration)', () => {
 
     const generated = runCli(['generate']);
     expect(generated.status).toBe(0);
-    writeFileSync(
-      join(TEST_DIR, 'CLAUDE.md'),
-      '# Manually edited generated output\n',
-    );
+    writeFileSync(join(TEST_DIR, 'CLAUDE.md'), '# Manually edited generated output\n');
 
     const { stdout, status } = runCli(['check', '--json']);
     const envelope = JSON.parse(stdout);
@@ -107,6 +104,42 @@ describe('agentsmesh --json output (integration)', () => {
     expect(envelope.data.outputDrift).toBe(true);
     expect(envelope.data.outputModified).toEqual(['CLAUDE.md']);
     expect(envelope.data.outputRemoved).toEqual([]);
+  });
+
+  it('check --json reports a missing generated output separately', () => {
+    setupValidProject();
+
+    const generated = runCli(['generate']);
+    expect(generated.status).toBe(0);
+    rmSync(join(TEST_DIR, 'CLAUDE.md'));
+
+    const { stdout, status } = runCli(['check', '--json']);
+    const envelope = JSON.parse(stdout);
+
+    expect(status).toBe(1);
+    expect(envelope.data.canonicalDrift).toBe(false);
+    expect(envelope.data.outputDrift).toBe(true);
+    expect(envelope.data.outputModified).toEqual([]);
+    expect(envelope.data.outputRemoved).toEqual(['CLAUDE.md']);
+  });
+
+  it('check --json reports a stale generated output separately', () => {
+    setupValidProject();
+
+    const generated = runCli(['generate']);
+    expect(generated.status).toBe(0);
+    const stalePath = join(TEST_DIR, '.cursor', 'rules', 'orphaned.mdc');
+    writeFileSync(stalePath, '# Stale generated output\n');
+
+    const { stdout, status } = runCli(['check', '--json']);
+    const envelope = JSON.parse(stdout);
+
+    expect(status).toBe(1);
+    expect(envelope.data.canonicalDrift).toBe(false);
+    expect(envelope.data.outputDrift).toBe(true);
+    expect(envelope.data.outputModified).toEqual([]);
+    expect(envelope.data.outputRemoved).toEqual([]);
+    expect(envelope.data.outputStale).toEqual(['.cursor/rules/orphaned.mdc']);
   });
 
   it('check --json reports no lock as failure', () => {

--- a/tests/integration/json-output.integration.test.ts
+++ b/tests/integration/json-output.integration.test.ts
@@ -88,6 +88,27 @@ describe('agentsmesh --json output (integration)', () => {
     expect(drifted.length).toBeGreaterThan(0);
   });
 
+  it('check --json reports generated-output drift separately', () => {
+    setupValidProject();
+
+    const generated = runCli(['generate']);
+    expect(generated.status).toBe(0);
+    writeFileSync(
+      join(TEST_DIR, 'CLAUDE.md'),
+      '# Manually edited generated output\n',
+    );
+
+    const { stdout, status } = runCli(['check', '--json']);
+    const envelope = JSON.parse(stdout);
+
+    expect(status).toBe(1);
+    expect(envelope.success).toBe(false);
+    expect(envelope.data.canonicalDrift).toBe(false);
+    expect(envelope.data.outputDrift).toBe(true);
+    expect(envelope.data.outputModified).toEqual(['CLAUDE.md']);
+    expect(envelope.data.outputRemoved).toEqual([]);
+  });
+
   it('check --json reports no lock as failure', () => {
     setupValidProject();
     // No generate run, so no .lock file

--- a/tests/integration/json-output.integration.test.ts
+++ b/tests/integration/json-output.integration.test.ts
@@ -140,6 +140,7 @@ describe('agentsmesh --json output (integration)', () => {
     expect(envelope.data.outputModified).toEqual([]);
     expect(envelope.data.outputRemoved).toEqual([]);
     expect(envelope.data.outputStale).toEqual(['.cursor/rules/orphaned.mdc']);
+    expect(existsSync(stalePath)).toBe(true);
   });
 
   it('check --json reports no lock as failure', () => {

--- a/tests/unit/cli/commands/check-edge-cases.test.ts
+++ b/tests/unit/cli/commands/check-edge-cases.test.ts
@@ -36,7 +36,7 @@ describe('runCheck — multi-drift structured data', () => {
     writeFileSync(
       join(TEST_DIR, 'agentsmesh.yaml'),
       `version: 1
-targets: [claude-code]
+targets: []
 features: [rules, mcp]
 collaboration:
   strategy: lock
@@ -89,7 +89,7 @@ packs: {}
     writeFileSync(
       join(TEST_DIR, 'agentsmesh.yaml'),
       `version: 1
-targets: [claude-code]
+targets: []
 features: [rules, hooks, permissions]
 collaboration:
   strategy: lock
@@ -127,7 +127,7 @@ describe('runCheck — lock format compatibility', () => {
   it('accepts a lock written by a pre-`packs` library version (missing packs field)', async () => {
     writeFileSync(
       join(TEST_DIR, 'agentsmesh.yaml'),
-      'version: 1\ntargets: [claude-code]\nfeatures: [rules]\n',
+      'version: 1\ntargets: []\nfeatures: [rules]\n',
     );
     mkdirSync(join(TEST_DIR, '.agentsmesh', 'rules'), { recursive: true });
     const body = '# stable';
@@ -153,7 +153,7 @@ extends: {}
   it('treats a malformed YAML lock as "no lock" and exits 1', async () => {
     writeFileSync(
       join(TEST_DIR, 'agentsmesh.yaml'),
-      'version: 1\ntargets: [claude-code]\nfeatures: [rules]\n',
+      'version: 1\ntargets: []\nfeatures: [rules]\n',
     );
     mkdirSync(join(TEST_DIR, '.agentsmesh', 'rules'), { recursive: true });
     writeFileSync(join(TEST_DIR, '.agentsmesh', 'rules', '_root.md'), '# x');

--- a/tests/unit/cli/commands/check.test.ts
+++ b/tests/unit/cli/commands/check.test.ts
@@ -23,7 +23,7 @@ afterEach(() => {
 
 describe('runCheck', () => {
   it('returns 0 when checksums match', async () => {
-    writeFileSync(join(TEST_DIR, 'agentsmesh.yaml'), 'version: 1');
+    writeFileSync(join(TEST_DIR, 'agentsmesh.yaml'), 'version: 1\ntargets: []\nfeatures: []');
     mkdirSync(join(TEST_DIR, '.agentsmesh', 'rules'), { recursive: true });
     const body = '# Rules';
     writeFileSync(join(TEST_DIR, '.agentsmesh', 'rules', '_root.md'), body);
@@ -42,20 +42,24 @@ extends: {}
     expect(result.exitCode).toBe(0);
     expect(result.data.hasLock).toBe(true);
     expect(result.data.inSync).toBe(true);
+    expect(result.data.canonicalDrift).toBe(false);
+    expect(result.data.outputDrift).toBe(false);
   });
 
   it('returns exitCode 1 when lock is missing', async () => {
-    writeFileSync(join(TEST_DIR, 'agentsmesh.yaml'), 'version: 1');
+    writeFileSync(join(TEST_DIR, 'agentsmesh.yaml'), 'version: 1\ntargets: []\nfeatures: []');
     mkdirSync(join(TEST_DIR, '.agentsmesh', 'rules'), { recursive: true });
     writeFileSync(join(TEST_DIR, '.agentsmesh', 'rules', '_root.md'), '# Rules');
     const result = await runCheck({}, TEST_DIR);
     expect(result.exitCode).toBe(1);
     expect(result.data.hasLock).toBe(false);
+    expect(result.data.canonicalDrift).toBe(false);
+    expect(result.data.outputDrift).toBe(false);
     expect(result.data.inSync).toBe(false);
   });
 
   it('returns exitCode 1 when checksums mismatch', async () => {
-    writeFileSync(join(TEST_DIR, 'agentsmesh.yaml'), 'version: 1');
+    writeFileSync(join(TEST_DIR, 'agentsmesh.yaml'), 'version: 1\ntargets: []\nfeatures: []');
     mkdirSync(join(TEST_DIR, '.agentsmesh', 'rules'), { recursive: true });
     writeFileSync(join(TEST_DIR, '.agentsmesh', 'rules', '_root.md'), '# Modified');
     writeFileSync(
@@ -73,10 +77,12 @@ extends: {}
     expect(result.data.hasLock).toBe(true);
     expect(result.data.inSync).toBe(false);
     expect(result.data.modified).toContain('rules/_root.md');
+    expect(result.data.canonicalDrift).toBe(true);
+    expect(result.data.outputDrift).toBe(false);
   });
 
   it('returns exitCode 1 when new file added (not in lock)', async () => {
-    writeFileSync(join(TEST_DIR, 'agentsmesh.yaml'), 'version: 1');
+    writeFileSync(join(TEST_DIR, 'agentsmesh.yaml'), 'version: 1\ntargets: []\nfeatures: []');
     mkdirSync(join(TEST_DIR, '.agentsmesh', 'rules'), { recursive: true });
     writeFileSync(join(TEST_DIR, '.agentsmesh', 'rules', '_root.md'), '# Rules');
     writeFileSync(join(TEST_DIR, '.agentsmesh', 'rules', 'new.md'), '# New');
@@ -101,7 +107,7 @@ extends: {}
     writeFileSync(join(baseDir, '.agentsmesh', 'rules', '_root.md'), '# Base');
     writeFileSync(
       join(TEST_DIR, 'agentsmesh.yaml'),
-      `version: 1\ntargets: [claude-code]\nfeatures: [rules]\nextends:\n  - name: base\n    source: ./base-config\n    features: [rules]\n`,
+      `version: 1\ntargets: []\nfeatures: [rules]\nextends:\n  - name: base\n    source: ./base-config\n    features: [rules]\n`,
     );
     mkdirSync(join(TEST_DIR, '.agentsmesh', 'rules'), { recursive: true });
     writeFileSync(join(TEST_DIR, '.agentsmesh', 'rules', '_root.md'), '# Local');
@@ -115,7 +121,7 @@ extends: {}
   });
 
   it('returns exitCode 1 when file removed from canonical', async () => {
-    writeFileSync(join(TEST_DIR, 'agentsmesh.yaml'), 'version: 1');
+    writeFileSync(join(TEST_DIR, 'agentsmesh.yaml'), 'version: 1\ntargets: []\nfeatures: []');
     mkdirSync(join(TEST_DIR, '.agentsmesh', 'rules'), { recursive: true });
     writeFileSync(join(TEST_DIR, '.agentsmesh', 'rules', '_root.md'), '# Rules');
     const h = 'sha256:' + 'a'.repeat(64);
@@ -139,6 +145,7 @@ extends: {}
     writeFileSync(
       join(TEST_DIR, 'agentsmesh.yaml'),
       `version: 1
+targets: []
 collaboration:
   strategy: lock
   lock_features: [rules]
@@ -162,6 +169,8 @@ packs: {}
     expect(result.exitCode).toBe(1);
     expect(result.data.lockedViolations).toContain('rules/_root.md');
     expect(result.data.modified).toContain('rules/_root.md');
+    expect(result.data.canonicalDrift).toBe(true);
+    expect(result.data.outputDrift).toBe(false);
   });
 
   it('reads ~/.agentsmesh/.lock when --global is set', async () => {
@@ -174,7 +183,7 @@ packs: {}
     mkdirSync(join(TEST_DIR, '.agentsmesh', 'rules'), { recursive: true });
     writeFileSync(
       join(TEST_DIR, '.agentsmesh', 'agentsmesh.yaml'),
-      'version: 1\ntargets: [claude-code]\nfeatures: [rules]\n',
+      'version: 1\ntargets: []\nfeatures: [rules]\n',
     );
     const body = '# Global Rules';
     writeFileSync(join(TEST_DIR, '.agentsmesh', 'rules', '_root.md'), body);
@@ -195,5 +204,7 @@ packs: {}
     expect(result.exitCode).toBe(0);
     expect(result.data.hasLock).toBe(true);
     expect(result.data.inSync).toBe(true);
+    expect(result.data.canonicalDrift).toBe(false);
+    expect(result.data.outputDrift).toBe(false);
   });
 });

--- a/tests/unit/cli/renderers/check.test.ts
+++ b/tests/unit/cli/renderers/check.test.ts
@@ -10,46 +10,61 @@ describe('renderCheck', () => {
       exitCode: 1,
       data: {
         hasLock: false,
+        canonicalDrift: false,
+        outputDrift: false,
         inSync: false,
         modified: [],
         added: [],
         removed: [],
         extendsModified: [],
         lockedViolations: [],
+        outputModified: [],
+        outputRemoved: [],
+        outputStale: [],
       },
     });
 
     expect(output.stderr()).toContain("Run 'agentsmesh generate' first");
   });
 
-  it('prints an in-sync success message', () => {
+  it('prints an in-sync success message for both drift checks', () => {
     renderCheck({
       exitCode: 0,
       data: {
         hasLock: true,
+        canonicalDrift: false,
+        outputDrift: false,
         inSync: true,
         modified: [],
         added: [],
         removed: [],
         extendsModified: [],
         lockedViolations: [],
+        outputModified: [],
+        outputRemoved: [],
+        outputStale: [],
       },
     });
 
-    expect(output.stdout()).toContain('Lock file is in sync.');
+    expect(output.stdout()).toContain('Lock file is in sync; generated outputs are in sync.');
   });
 
-  it('prints every conflict bucket and marks only locked violations', () => {
+  it('prints every canonical conflict bucket and marks only locked violations', () => {
     renderCheck({
       exitCode: 1,
       data: {
         hasLock: true,
+        canonicalDrift: true,
+        outputDrift: false,
         inSync: false,
         extendsModified: ['pack-a'],
         modified: ['rules/root.md', 'rules/open.md'],
         added: ['commands/deploy.md', 'commands/open.md'],
         removed: ['skills/old/SKILL.md', 'skills/open/SKILL.md'],
         lockedViolations: ['rules/root.md', 'commands/deploy.md', 'skills/old/SKILL.md'],
+        outputModified: [],
+        outputRemoved: [],
+        outputStale: [],
       },
     });
 
@@ -63,5 +78,32 @@ describe('renderCheck', () => {
     expect(errors).toContain('skills/old/SKILL.md was removed [LOCKED]');
     expect(errors).toContain('skills/open/SKILL.md was removed\n');
     expect(output.stdout()).toContain("Run 'agentsmesh merge' to resolve");
+  });
+
+  it('prints modified, missing, and stale generated outputs with the regeneration fix', () => {
+    renderCheck({
+      exitCode: 1,
+      data: {
+        hasLock: true,
+        canonicalDrift: false,
+        outputDrift: true,
+        inSync: false,
+        modified: [],
+        added: [],
+        removed: [],
+        extendsModified: [],
+        lockedViolations: [],
+        outputModified: ['CLAUDE.md'],
+        outputRemoved: ['.cursor/rules/general.mdc'],
+        outputStale: ['.cursor/rules/orphaned.mdc'],
+      },
+    });
+
+    const errors = output.stderr();
+    expect(errors).toContain('Generated output drift detected:');
+    expect(errors).toContain('CLAUDE.md was modified');
+    expect(errors).toContain('.cursor/rules/general.mdc is missing');
+    expect(errors).toContain('.cursor/rules/orphaned.mdc is stale (no longer generated)');
+    expect(output.stdout()).toContain("Run 'agentsmesh generate' and commit the updated outputs.");
   });
 });

--- a/website/src/content/docs/cli/check.mdx
+++ b/website/src/content/docs/cli/check.mdx
@@ -1,10 +1,10 @@
 ---
 draft: false
 title: agentsmesh check
-description: Verify that canonical files still match the lock file. Designed for CI pipelines — exits with code 1 if generated files have drifted from the lock.
+description: Verify canonical lock state and generated outputs. Designed for CI pipelines — exits with code 1 if either source or projection drift is detected.
 ---
 
-Verify that the canonical files still match the lock file (`.agentsmesh/.lock`). Designed for CI pipelines — exits with code 1 if generated files have drifted.
+Verify both sides of the AgentsMesh contract: canonical files against `.agentsmesh/.lock`, and generated tool files against the current canonical projection. The command exits with code 1 if either side has drifted.
 
 ## Usage
 
@@ -20,16 +20,18 @@ agentsmesh check --global
 
 | Flag | Description |
 |------|-------------|
-| `--global` | Check `~/.agentsmesh/.lock` instead of the current project lock. |
+| `--global` | Check the user-level canonical lock and generated outputs instead of the current project. |
 
 ## What drift means
 
 Drift occurs when:
 - Someone edited `.agentsmesh/` but forgot to run `agentsmesh generate`
-- Someone edited a generated file (`.claude/`, `.cursor/`, etc.) directly
-- A pull request merged changes to canonical config without regenerating
+- Someone edited or deleted a generated file (`.claude/`, `.cursor/`, `AGENTS.md`, etc.) directly
+- A managed generated file remains after its canonical source is removed
+- A pull request merged canonical changes without regenerating
+- An `extends` source changed without refreshing the lock
 
-`agentsmesh check` catches all of these by comparing current file checksums against the stored lock.
+`agentsmesh check` first compares canonical checksums and extends against the collaboration lock, then compares the current projection and scans managed output locations for stale files. JSON output exposes `canonicalDrift` and `outputDrift` separately, plus `outputModified`, `outputRemoved`, and `outputStale` paths.
 
 ## CI integration
 
@@ -39,7 +41,7 @@ Drift occurs when:
   run: agentsmesh check
 ```
 
-This step fails the build if generated files are out of date with canonical sources.
+This step fails the build if canonical sources or generated outputs are out of date.
 
 For user-level config checks, run `agentsmesh check --global` on a machine that owns the home-level AgentsMesh config.
 
@@ -67,12 +69,12 @@ jobs:
 
 | Code | Meaning |
 |------|---------|
-| `0` | All generated files match the lock. |
-| `1` | Drift detected — one or more files are out of sync. |
+| `0` | Canonical state and generated outputs are both in sync. |
+| `1` | The lock is missing, canonical drift exists, or generated-output drift exists. |
 
 ## Difference between `check` and `generate --check`
 
-- `agentsmesh check` — fast: reads lock file and checks current file hashes. Does not run the full generation pipeline.
-- `agentsmesh generate --check` — slower: runs the full generation pipeline and compares output to what's on disk. More thorough but takes longer.
+- `agentsmesh check` — the complete CI gate: requires the collaboration lock, validates canonical/extends state, and verifies all configured generated outputs.
+- `agentsmesh generate --check` — focuses on output verification and supports generation filters such as `--targets`; configured lock-feature guards still apply unless `--force` is used.
 
-For CI pipelines where speed matters, use `agentsmesh check`. Use `generate --check` when you want to verify the full generation path.
+Use `agentsmesh check` for the normal committed-project CI contract. Use `generate --check` when you only need projection verification or want to inspect a target subset.

--- a/website/src/content/docs/cli/generate.mdx
+++ b/website/src/content/docs/cli/generate.mdx
@@ -67,7 +67,7 @@ Shows a unified diff of what would change without writing any files. Useful befo
 agentsmesh generate --check
 ```
 
-Exits 0 if generated files match the lock file. Exits 1 if drift is detected. Use this in CI pipelines instead of `agentsmesh check` when you want the full generation path to be verified.
+Exits 0 if generated files match the current canonical projection and exits 1 if output drift is detected. This mode can verify a filtered target set; configured `lock_features` guards still apply unless `--force` is used.
 
 ### Force through locks
 

--- a/website/src/content/docs/guides/ci-drift-detection.mdx
+++ b/website/src/content/docs/guides/ci-drift-detection.mdx
@@ -13,10 +13,11 @@ Add `agentsmesh check` and `agentsmesh lint` to your CI pipeline to catch config
 **Drift** happens when:
 - Someone edits `.agentsmesh/` but forgets to run `agentsmesh generate`
 - Someone edits a generated file (`.claude/`, `.cursor/`, etc.) directly
+- A generated file remains in a managed output location after its canonical source is removed
 - A PR merges canonical changes without regenerating
 - An `extends` source changes and the project hasn't refreshed
 
-`agentsmesh check` detects all of these by comparing current file hashes against the stored lock.
+`agentsmesh check` detects all of these by combining canonical lock comparison with a full generated-output projection check.
 
 ## Basic CI setup
 
@@ -61,9 +62,11 @@ Fails with exit code 1 if any lint errors are found.
 
 ### `agentsmesh check`
 
-Verifies that generated tool directories match the canonical sources:
-- Compares file hashes against `.agentsmesh/.lock`
-- Fails with exit code 1 if any file has drifted
+Verifies both sides of the sync contract:
+- Compares canonical files and extends against `.agentsmesh/.lock`
+- Compares generated tool files against the current canonical projection
+- Detects stale files under managed generated-output locations
+- Fails with exit code 1 if either canonical or generated-output drift exists
 
 ## Automated fix comment
 


### PR DESCRIPTION
## Summary

- make `agentsmesh check` fail when generated outputs are modified, missing, or stale
- distinguish canonical drift from generated-output drift in JSON with `canonicalDrift` and `outputDrift`
- report actionable `outputModified`, `outputRemoved`, and `outputStale` paths
- reuse the existing managed-output cleanup inventory for read-only stale detection
- update the CLI and CI drift documentation and add a patch changeset

## Root cause

`agentsmesh check` only compared canonical files under `.agentsmesh/` with `.agentsmesh/.lock`. It never projected the current canonical state and compared the generated files on disk, so direct output edits could pass CI.

Stale outputs also do not appear in the current generation result. The existing cleanup path knew which output locations AgentsMesh manages, but that discovery was only used by write-mode generation. This change extracts read-only stale discovery for `check`; deletion remains exclusive to normal `agentsmesh generate`.

## Validation

- integration JSON suite: 15/15 passed
- focused check, renderer, target-contract, and stale-cleanup suites: 178/178 passed
- build passed
- lint passed
- typecheck passed
- documentation site build passed

Fixes #98